### PR TITLE
Start H2 before Jetty

### DIFF
--- a/roninit/src/ronin/DevServer.java
+++ b/roninit/src/ronin/DevServer.java
@@ -54,10 +54,10 @@ public class DevServer {
       log("Environment properties are: " + new RoninServletWrapper().getEnvironmentProperties(new File(args[2])));
       int port = Integer.parseInt(args[1]);
       String root = args[2];
-      startJetty(port, root);
       if ("server".equals(args[0])) {
         startH2(args[2]);
       }
+      startJetty(port, root);
       log("\nYour Ronin App is listening at http://localhost:8080\n");
     } else if ("upgrade_db".equals(args[0])) {
       resetDb(args[1]);


### PR DESCRIPTION
Our RoninConfig pulls up beans via Tosa in the constructor which fails if the db doesn't exist. The second run of the server then wakes up to a created db and startup succeeds (bootstrap problem). I tried a delayed execution of the code in that constructor and found that the code then succeeds as well. So I went digging and found DevServer, where we start H2 and execute the statements in the .ddl after starting Jetty. Which is fine for web requests, but didn't work when we were making H2 requests in the Jetty startup. So, it seems correct for this scenario to start H2 (and run the statements) before Jetty startup.
