### PR TITLE
Upgrade Gosu dependencies from 0.9-11 to 0.9-12

### DIFF
--- a/build.vark
+++ b/build.vark
@@ -142,7 +142,7 @@ function test(log:boolean = false) {
              .withFile(roninitHome.file("build").file("roninit.jar"))
              .withFileset(gosuHome.file("jars").fileset())
   if(log) {
-    cp = cp.withFile(roninlogHome.file("build").file("roninlog.jar"))
+    cp = cp.withFile(roninLogHome.file("build").file("roninlog.jar"))
   }
 
   Ant.java(:classpath=cp,

--- a/roblog/pom.xml
+++ b/roblog/pom.xml
@@ -126,7 +126,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/ronin-init/pom.xml
+++ b/ronin-init/pom.xml
@@ -93,7 +93,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/ronin-init/src/vark/RoninVarkTargets.gsx
+++ b/ronin-init/src/vark/RoninVarkTargets.gsx
@@ -28,7 +28,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
                :destdir = classesDir,
                :classpath = this.classpath(this.file("src").fileset())
                                 .withPath(fixedPom().dependencies(COMPILE, :additionalDeps = {
-                new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+                new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
             }).Path),
         :debug = true,
         :includeantruntime = false)
@@ -43,7 +43,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("env", "A comma-separated list of environment variables, formatted as \"ronin.name=value\".")
   function server(waitForDebugger : boolean, dontStartDB : boolean, port : int = 8080, env : String = "") {
     var cp = fixedPom().dependencies(RUNTIME, :additionalDeps = {
-        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path.withFile(this.file("classes"))
     Ant.java(:classpath=cp,
                    :jvmargs=getJvmArgsString(waitForDebugger) + " " + env.split(",").map(\e -> "-D" + e).join(" "),
@@ -58,7 +58,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("waitForDebugger", "Suspend the server until a debugger connects.")
   function resetDb(waitForDebugger : boolean) {
     var cp = fixedPom().dependencies(RUNTIME, :additionalDeps = {
-        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path
     Ant.java(:classpath=cp,
                    :jvmargs=getJvmArgsString(waitForDebugger),
@@ -75,7 +75,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("env", "A comma-separated list of environment variables, formatted as \"ronin.name=value\".")
   function verifyApp(waitForDebugger : boolean, env : String = "") {
     var cp = fixedPom().dependencies(TEST, :additionalDeps = {
-        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path
     Ant.java(:classpath=cp,
                    :classname="ronin.DevServer",
@@ -133,7 +133,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
     libDir.mkdirs()
 
     var cp = fixedPom().dependencies(TEST, :additionalDeps = {
-        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu", :Version = "0.9-11" }
+        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu", :Version = "0.9-12" }
     }).Path
 
     cp.list().each( \ elt -> {
@@ -159,7 +159,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("trace", "Enable detailed tracing.")
   function test(waitForDebugger : boolean, parallelClasses : boolean, parallelMethods : boolean, trace : boolean, env : String = "") {
     var cp = fixedPom().dependencies(TEST, :additionalDeps = {
-        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new(){ : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path
 
     Ant.java(:classpath=cp,
@@ -183,7 +183,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("trace", "Enable detailed tracing.")
   function uiTest(waitForDebugger : boolean, parallelClasses : boolean, parallelMethods : boolean, trace : boolean, port : int = 8080, env : String = "") {
     var cp = fixedPom().dependencies(TEST, :additionalDeps = {
-        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path
 
     Ant.java(:classpath=cp,
@@ -204,7 +204,7 @@ enhancement RoninVarkTargets : gw.vark.AardvarkFile {
   @Param("password", "The password with which to connect to the admin console.")
   function console(port : String = "8022", username : String = "admin", password : String = "password") {
     var cp = fixedPom().dependencies(RUNTIME, :additionalDeps = {
-        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-11" }
+        new() { : GroupId = "org.gosu-lang.gosu", :ArtifactId = "gosu-core", :Version = "0.9-12" }
     }).Path
 
     Ant.java(:classpath=cp,

--- a/ronin-init/template/pom.xml
+++ b/ronin-init/template/pom.xml
@@ -127,7 +127,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/ronin-log/pom.xml
+++ b/ronin-log/pom.xml
@@ -57,7 +57,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/ronin-test/pom.xml
+++ b/ronin-test/pom.xml
@@ -69,7 +69,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/ronin/pom.xml
+++ b/ronin/pom.xml
@@ -112,7 +112,7 @@
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
-          <gosuVersion>0.9-11</gosuVersion>
+          <gosuVersion>0.9-12</gosuVersion>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
I was trying to make-war on the ronin startup kit and it failed trying to get gosu 0.9-11. I forked ronin itself to look at the project and found two issues:
- 0.9-11 is littered everywhere, in the pom.xml files and in the build.vark files
- With the new Gosu case-sensitivity, the root build.vark fails to compile line 145 on account of roninlogHome not being roninLogHome
